### PR TITLE
[Windows] Converter not found

### DIFF
--- a/src/SurfingApp/App.xaml
+++ b/src/SurfingApp/App.xaml
@@ -5,6 +5,8 @@
              x:Class="SurfingApp.App">
     <Application.Resources>
         <ResourceDictionary>
+            <converters:ToUpperConverter x:Key="ToUpperConverter" />
+            
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Resources/Styles/Colors.xaml" />
                 <ResourceDictionary Source="Resources/Styles/Styles.xaml" />

--- a/src/SurfingApp/Views/HomeView.xaml
+++ b/src/SurfingApp/Views/HomeView.xaml
@@ -10,7 +10,7 @@
     <ContentPage.Resources>
         <ResourceDictionary>
 
-            <converters:ToUpperConverter x:Key="ToUpperConverter" />
+            
 
             <Style x:Key="HeaderLayoutStyle" TargetType="Grid">
                 <Setter Property="VerticalOptions" Value="Center" />


### PR DESCRIPTION
### Root Cause
The ToUpperConverter is utilized in HomeView.xaml and PostItemTemplate.xaml, but it is initialized only in HomeView.xaml. This causes an exception to be thrown from PostItemTemplate.xaml.
 
### Description of Issue Fix
The fix involved initializing the Converter in App.xaml and utilizing it in both the HomeView and PostItemTemplate pages.
 
### Issues Fixed
 
Fixes https://github.com/dotnet/maui/issues/9484
